### PR TITLE
update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, mirleft
+Copyright (c) 2014, David Kaloper and Hannes Mehnert
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
mirleft is not a legal entity (afaik) so seems incorrect to claim
it can hold copyright. I've taken the same copyright from ocaml-tls
and copied that across to this License file.
